### PR TITLE
[docs] fix pattern object style in the code example

### DIFF
--- a/website/reference/rule.md
+++ b/website/reference/rule.md
@@ -32,7 +32,7 @@ A `String` pattern will match one single AST node according to [pattern syntax](
 
 ```yaml
 pattern:
-  kind: field_definition
+  selector: field_definition
   context: class { $F }
 ```
 


### PR DESCRIPTION
From [the following source code](https://github.com/ast-grep/ast-grep/blob/e42de9d1e613dda687393d247ab3d847e4760ee0/crates/config/src/rule.rs#L-95-L97), it appears that the object-style code example is not correct.
I thought it should be `selector`, not `kind`.



```rs
pub enum PatternStyle {
  Str(String),
  Contextual { context: String, selector: String },
}
```