### PR TITLE
Fix schema validation in playground & rule in test setup guide

### DIFF
--- a/website/guide/test-rule.md
+++ b/website/guide/test-rule.md
@@ -64,6 +64,8 @@ rule:
         any:
           - kind: for_in_statement
           - kind: while_statement
+        stopBy:
+          end
     - pattern: await $_
 ```
 

--- a/website/public/schema.json
+++ b/website/public/schema.json
@@ -292,10 +292,10 @@
       ],
       "properties": {
         "expandEnd": {
-          "$ref": "#/definitions/Maybe_Relation"
+          "$ref": "#/definitions/Relation"
         },
         "expandStart": {
-          "$ref": "#/definitions/Maybe_Relation"
+          "$ref": "#/definitions/Relation"
         },
         "template": {
           "type": "string"


### PR DESCRIPTION
### Context

This PR tries to address the following issues:

1. There appears to be some schema validation issue in the playground:
<img width="750" alt="image" src="https://github.com/ast-grep/ast-grep.github.io/assets/6988974/8b76a3b6-cc87-4990-bc58-e6658f7bab1c">

2. Additionally, the sample `no-await-in-loop` rule in the [Test Setup page](https://ast-grep.github.io/guide/test-rule.html#test-setup) wasn't working.

Here's a [playground link](https://ast-grep.github.io/playground.html#eyJtb2RlIjoiQ29uZmlnIiwibGFuZyI6ImphdmFzY3JpcHQiLCJxdWVyeSI6ImNvbnNvbGUubG9nKCRNQVRDSCkiLCJyZXdyaXRlIjoibG9nZ2VyLmxvZygkTUFUQ0gpIiwiY29uZmlnIjoiaWQ6IG5vLWF3YWl0LWluLWxvb3Bcbm1lc3NhZ2U6IERvbid0IHVzZSBhd2FpdCBpbnNpZGUgb2YgbG9vcHNcbnNldmVyaXR5OiB3YXJuaW5nXG5sYW5ndWFnZTogVHlwZVNjcmlwdFxucnVsZTpcbiAgYWxsOlxuICAgIC0gaW5zaWRlOlxuICAgICAgICBhbnk6XG4gICAgICAgICAgLSBraW5kOiBmb3JfaW5fc3RhdGVtZW50XG4gICAgICAgICAgLSBraW5kOiB3aGlsZV9zdGF0ZW1lbnRcbiAgICAtIHBhdHRlcm46IGF3YWl0ICRfIiwic291cmNlIjoiYXN5bmMgZnVuY3Rpb24gZm9vKCkgeyBmb3IgKHZhciBiYXIgb2YgYmF6KSBhd2FpdCBiYXI7IH0ifQ==) to show that it is not catching the invalid test case from the guide itself.

### Changes

1. We change `#/definitions/Maybe_Relation` to `#/definitions/Relation` since the former was removed in https://github.com/ast-grep/ast-grep.github.io/commit/b96480ceeccf1747ac7f8fd448d0ed480e1aed61
2. We add a `stopBy: end` to the rule since the await expression is not a direct descendant of the for-in/while statements.