### PR TITLE
docs: fix typo

### DIFF
--- a/website/guide/rule-config/composite-rule.md
+++ b/website/guide/rule-config/composite-rule.md
@@ -29,9 +29,9 @@ We can read the rule as "matches code that is both an expression statement and h
 ```yaml
 rule:
   any:
-    - pattern: var a = $
-    - pattern: const a = $
-    - pattern: let a = $
+    - pattern: var a = $A
+    - pattern: const a = $A
+    - pattern: let a = $A
 ```
 
 The above rule will match any variable declaration statement, like `var a = 1`, `const a = 1` and `let a = 1`.


### PR DESCRIPTION
On the page `website/guide/rule-config/composite-rule.md` of section `any`, the example yml doesn't work in the playground.

Refer to https://ast-grep.github.io/guide/pattern-syntax.html#meta-variable, `$` is an invalid meta variable.

So I change the yml as follows

```yaml
rule:
  any:
    - pattern: var a = $A
    - pattern: const a = $A
    - pattern: let a = $A
```