### PR TITLE
fix(website): fix the error word 'metavaraibles' to 'meta variables'

### DIFF
--- a/website/guide/rule-config/composite-rule.md
+++ b/website/guide/rule-config/composite-rule.md
@@ -26,7 +26,7 @@ But not `var ret = console.log('Hello World');` because the `console.log` call i
 We can read the rule as "matches code that is both an expression statement and has content `console.log('Hello World')`".
 
 :::tip Pro Tip
-`all` rule guarantees the order of rule matching. If you use pattern with metavaraibles, make sure to use `all` array to guarantee rule execution order.
+`all` rule guarantees the order of rule matching. If you use pattern with [meta variables](/guide/pattern-syntax.html#meta-variable-capturing), make sure to use `all` array to guarantee rule execution order.
 :::
 
 ## `any`
@@ -134,4 +134,4 @@ It has less indentation than before. See the rewritten rule [in action](/playgro
 Rule object does not guarantee the order of rule matching. It is possible that the `inside` rule matches before the `pattern` rule in the example above.
 :::
 
-Rule order is not important if rules are independent. However, matching metavaraible in patterns depends on the result of previous pattern matching. If you use pattern with metavaraibles, make sure to use `all` array to guarantee rule execution order.
+Rule order is not important if rules are independent. However, matching metavaraible in patterns depends on the result of previous pattern matching. If you use pattern with [meta variables](/guide/pattern-syntax.html#meta-variable-capturing), make sure to use `all` array to guarantee rule execution order.


### PR DESCRIPTION
fix the error word `metavaraibles` to `meta variables` in `/website/guide/rule-config/composite-rule.md`