### PR TITLE
doc: remove vue-vine from ecosystem

### DIFF
--- a/website/src/homepage/Ecosystem.vue
+++ b/website/src/homepage/Ecosystem.vue
@@ -4,9 +4,6 @@
       <h1>Who is using ast-grep</h1>
     </div>
     <div class="ecosystem">
-      <a target="_blank" href="https://vue-vine.dev/" title="vue-vine" class="sponsor">
-        <img src='https://vue-vine.dev/vine-logo.png'/>
-      </a>
       <a target="_blank" href="https://swc.rs" title="SWC" class="sponsor">
         <img src='https://avatars.githubusercontent.com/u/26715726?s=200&v=4'/>
       </a>


### PR DESCRIPTION
In the ['Who is using ast-grep?' github issue](https://github.com/ast-grep/ast-grep/issues/373), vue-vine was reportedly using ast-grep instead of babel to parse ASTs. However, as of July 25, 2023, [vue-vine has returned to using babel](https://github.com/vue-vine/vue-vine/commit/ab79b6352905ac1abb79e51f6700f372ebd1868b).

ast-grep.github.io has two more references to vue-vine but they are both still relevant.
1. Language Injection example for ast-grep to support vue-vine
2. Link to file showing how vue-vine used ast-grep NAPI from before they switched back to babel