### PR TITLE
fix: Improve text color of Share button in dark mode

### DIFF
--- a/website/src/components/Toolbars.vue
+++ b/website/src/components/Toolbars.vue
@@ -75,6 +75,7 @@ async function onShare() {
     position: absolute;
     left: -10%;
     bottom: 50%;
+    color: var(--vp-c-white);
     background-color: rgba(0, 0, 0, 0.5);
     padding: 0.25em 0.5em;
     font-size: 10px;
@@ -83,6 +84,10 @@ async function onShare() {
     transform: translate(-100%, 50%);
     transition: 0.2s;
     border-radius: 5px;
+  }
+  
+  .dark [title]:after {
+    color: var(--vp-c-brand-1);
   }
 
   [title]:hover:after {


### PR DESCRIPTION
**Before**
<img width="400" alt="スクリーンショット 2024-10-12 23 58 49" src="https://github.com/user-attachments/assets/65df7dfe-a3db-4ae5-997d-43d107ab9fbb">

**After**
<img width="400" alt="スクリーンショット 2024-10-12 23 57 24" src="https://github.com/user-attachments/assets/685f511c-985d-456e-a6ab-5cd7955d1b85">