### PR TITLE
fix: reference/yaml.md

### DIFF
--- a/website/reference/yaml.md
+++ b/website/reference/yaml.md
@@ -237,6 +237,11 @@ To disable this behavior, use [`--no-ignore`](/reference/cli.html#scan) in CLI.
 `ignores` is a rule-wise configuration that only filters files that are not ignored by the CLI.
 :::
 
+:::warning Don't add `./`
+Be sure to remove `./` to the beginning of your rules. ast-grep will not recognize the paths if you add `./`.
+:::
+
+
 ## Other
 
 ### `url`


### PR DESCRIPTION
add warning for dont add ./ in globbing section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a warning note about path configuration in YAML for ast-grep
  - Clarified that paths starting with `./` are not recognized by the tool
  - Provided guidance for correct rule path configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->