### PR TITLE
feat: MetaVar panel view the current match

### DIFF
--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -5,7 +5,7 @@
   --vp-c-brand-2: #a89f2a;
   --vp-c-brand-1: #918623;
   --vp-c-brand-3: #2f4f6d;
-  --vp-custom-selctor-option-text: #213547;
+  --vp-custom-selector-option-text: #213547;
 
 
   --vp-custom-block-tip-text: var(--vp-c-text-1);
@@ -13,5 +13,5 @@
   --vp-custom-block-tip-code-bg: var(--vp-c-green-soft);
 }
 .dark {
-  --vp-custom-selctor-option-text: #213547;
+  --vp-custom-selector-option-text: #213547;
 }

--- a/website/src/components/EnvDisplay.vue
+++ b/website/src/components/EnvDisplay.vue
@@ -48,6 +48,14 @@ function decrement() {
           </td>
         </tr>
       </tbody>
+      <tfoot>
+        <tr>
+          <td colspan="2">
+            Now it's the {{ currentIndex + 1 }}th matched
+            <span class="match-count">({{ currentIndex + 1 }}/{{props.envs.length}})</span>
+          </td>
+        </tr>
+      </tfoot>
     </table>
     <div class="choose-match">
       <button @click="decrement">Prev Match</button>
@@ -96,6 +104,9 @@ function decrement() {
 .metavar-table td:nth-child(2n) {
   border-left: 1px solid var(--vp-c-divider);
   width: 75%;
+}
+.metavar-table tfoot .match-count {
+  color: #999;
 }
 .choose-match {
   margin-top: 1em;

--- a/website/src/components/SelectLang.vue
+++ b/website/src/components/SelectLang.vue
@@ -32,7 +32,7 @@ select {
   cursor: pointer;
 }
 .selector-option-text {
-  color: var(--vp-custom-selctor-option-text);
+  color: var(--vp-custom-selector-option-text);
 }
 @media only screen and (max-width: 780px) {
   .selector {


### PR DESCRIPTION
before: 
<img width="516" alt="image" src="https://github.com/user-attachments/assets/2c7927e9-656f-4545-8264-815adc10fb39" />


after:
<img width="836" alt="image" src="https://github.com/user-attachments/assets/1af69ecf-e2a2-41e2-9cd7-cedcba964ad2" />

close #648 #538


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in CSS variable name `--vp-custom-selctor-option-text` to `--vp-custom-selector-option-text` across multiple files
	- Updated styling reference in `SelectLang.vue` to use the correct CSS variable

- **New Features**
	- Added a footer section in `EnvDisplay.vue` to show current match index and total environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->