### PR TITLE
docs: New example for avoiding nested links in TSX

### DIFF
--- a/website/catalog/index.md
+++ b/website/catalog/index.md
@@ -47,5 +47,6 @@ Feel free to join our [Discord](https://discord.gg/4YZjf6htSQ) channel and ask @
   * [Unnecessary React Hook](/catalog/tsx/#avoid-unnecessary-react-hook)
   * [Unnecessary `useState` Type](/catalog/tsx/#unnecessary-usestate-type)
   * [Reverse React Compiler™](/catalog/tsx/#reverse-react-compilertm)
+  * [Avoid nested links](/catalog/tsx/#avoid-nested-links)
 * [YAML](/catalog/yaml/)
   * [Find key/value and show message](/catalog/yaml/#find-key-value-and-show-message-using-those-key-vals)

--- a/website/catalog/tsx/avoid-nested-links.md
+++ b/website/catalog/tsx/avoid-nested-links.md
@@ -1,0 +1,39 @@
+## Avoid nested links
+* [Playground Link](https://ast-grep.github.io/playground.html#eyJtb2RlIjoiQ29uZmlnIiwibGFuZyI6InRzeCIsInF1ZXJ5IjoiaWYgKCRBKSB7ICQkJEIgfSIsInJld3JpdGUiOiJpZiAoISgkQSkpIHtcbiAgICByZXR1cm47XG59XG4kJCRCIiwic3RyaWN0bmVzcyI6InNtYXJ0Iiwic2VsZWN0b3IiOiIiLCJjb25maWciOiJpZDogbm8tbmVzdGVkLWxpbmtzXG5sYW5ndWFnZTogdHN4XG5zZXZlcml0eTogZXJyb3JcbnJ1bGU6XG4gIHBhdHRlcm46IDxhICQkJD4kJCRBPC9hPlxuICBoYXM6XG4gICAgcGF0dGVybjogPGEgJCQkPiQkJDwvYT5cbiAgICBzdG9wQnk6IGVuZCIsInNvdXJjZSI6ImZ1bmN0aW9uIENvbXBvbmVudCgpIHtcbiAgcmV0dXJuIDxhIGhyZWY9Jy9kZXN0aW5hdGlvbic+XG4gICAgPGEgaHJlZj0nL2Fub3RoZXJkZXN0aW5hdGlvbic+TmVzdGVkIGxpbmshPC9hPlxuICA8L2E+O1xufVxuZnVuY3Rpb24gT2theUNvbXBvbmVudCgpIHtcbiAgcmV0dXJuIDxhIGhyZWY9Jy9kZXN0aW5hdGlvbic+XG4gICAgSSBhbSBqdXN0IGEgbGluay5cbiAgPC9hPjtcbn0ifQ==)
+
+### Description
+
+React will produce a warning message if you nest a link element inside of another link element. This rule will catch this mistake!
+
+
+### YAML
+
+```yaml
+id: no-nested-links
+language: tsx
+severity: error
+rule:
+  pattern: <a $$$>$$$A</a>
+  has:
+    pattern: <a $$$>$$$</a>
+    stopBy: end
+```
+
+### Example
+
+<!-- highlight matched code in curly-brace {lineNum} -->
+```tsx {1-5}
+function Component() {
+  return <a href='/destination'>
+    <a href='/anotherdestination'>Nested link!</a>
+  </a>;
+}
+function OkayComponent() {
+  return <a href='/destination'>
+    I am just a link.
+  </a>;
+}
+```
+
+### Contributed by
+[Tom MacWright](https://macwright.com/)

--- a/website/catalog/tsx/index.md
+++ b/website/catalog/tsx/index.md
@@ -14,3 +14,4 @@ In order to reduce rule duplication, you can use the [`languageGlobs`](/referenc
 <!--@include: ./rewrite-mobx-component.md-->
 <!--@include: ./unnecessary-react-hook.md-->
 <!--@include: ./reverse-react-compiler.md-->
+<!--@include: ./avoid-nested-links.md-->


### PR DESCRIPTION
Adds a new example for preventing the warning in React in which you accidentally nest an `<a>` element inside another `<a>` element. I think this might be helpful as well because the TSX examples currently don't have any examples of using `pattern` to specify a JSX element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new rule "Avoid nested links" to the TSX catalog
  - Expanded documentation with details about nesting link elements in React
  - Included new documentation file for the nested links rule

<!-- end of auto-generated comment: release notes by coderabbit.ai -->