### PR TITLE
Address a couple of typos in examples

### DIFF
--- a/website/guide/rewrite-code.md
+++ b/website/guide/rewrite-code.md
@@ -23,7 +23,7 @@ You can also use the `--update-all` or `-U` flag to automatically accept the cha
 
 Another way to rewrite code is to use the `fix` option in a YAML rule file. This option allows you to specify more complex and flexible rewrite rules, such as using transformations and regular expressions.
 
-Let's look at a simple example of using `fix` in a YAML rule ([playground Link](https://ast-grep.github.io/playground.html#eyJtb2RlIjoiQ29uZmlnIiwibGFuZyI6InB5dGhvbiIsInF1ZXJ5IjoiZGVmIGZvbygkWCk6XG4gICRTIiwicmV3cml0ZSI6ImxvZ2dlci5sb2coJE1BVENIKSIsImNvbmZpZyI6ImlkOiBjaGFuZ2VfbmFtZVxubGFuZ3VhZ2U6IFB5dGhvblxucnVsZTpcbiAgcGF0dGVybjogfFxuICAgIGRlZiBmb28oJFgpOlxuICAgICAgJCQkU1xuZml4OiB8LVxuICBkZWYgYmF6KCRYKTpcbiAgICAkJCRTXG4tLS1cbmlkOiBjaGFuZ2VfcGFyYW1cbnJ1bGU6XG4gIHBhdHRlcm46IGZvbygkWClcbmZpeDogYmF6KG4pIiwic291cmNlIjoiZGVmIGZvbyh4KTpcbiAgICByZXR1cm4geCArIDFcblxueSA9IGZvbygyKVxucHJpbnQoeSkifQ==)).
+Let's look at a simple example of using `fix` in a YAML rule ([playground Link](https://ast-grep.github.io/playground.html#eyJtb2RlIjoiQ29uZmlnIiwibGFuZyI6InB5dGhvbiIsInF1ZXJ5IjoiZGVmIGZvbygkWCk6XG4gICRTIiwicmV3cml0ZSI6ImxvZ2dlci5sb2coJE1BVENIKSIsInN0cmljdG5lc3MiOiJzbWFydCIsInNlbGVjdG9yIjoiIiwiY29uZmlnIjoiaWQ6IGNoYW5nZV9uYW1lXG5sYW5ndWFnZTogUHl0aG9uXG5ydWxlOlxuICBwYXR0ZXJuOiB8XG4gICAgZGVmIGZvbygkWCk6XG4gICAgICAkJCRTXG5maXg6IHwtXG4gIGRlZiBiYXooJFgpOlxuICAgICQkJFNcbi0tLVxuaWQ6IGNoYW5nZV9wYXJhbVxucnVsZTpcbiAgcGF0dGVybjogZm9vKCRYKVxuZml4OiBiYXooJFgpIiwic291cmNlIjoiZGVmIGZvbyh4KTpcbiAgICByZXR1cm4geCArIDFcblxueSA9IGZvbygyKVxucHJpbnQoeSkifQ==)).
 Suppose we have a Python file named `test.py` with the following content:
 
 ```python
@@ -65,8 +65,8 @@ This will show us the following diff:
 
 ```python
 def foo(x): # [!code --]
-def baz(n): # [!code ++]
-    return n + 1
+def baz(x): # [!code ++]
+    return x + 1
 
 y = foo(2) # [!code --]
 y = baz(2) # [!code ++]


### PR DESCRIPTION
Thanks for all your hard work on this tool! Very useful!

The playground link contained a typo in the `change_param` rule fix. Additionally, the inline diff of the function definition change had an error in the parameter name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised the guide's YAML example by updating the link with additional parameters to provide more precise guidance.
	- Improved formatting for clarity and consistency in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->