### PR TITLE
[doc] Clarify optional vs. required fields in the pattern object.

### DIFF
--- a/website/guide/rule-config/atomic-rule.md
+++ b/website/guide/rule-config/atomic-rule.md
@@ -28,9 +28,9 @@ For example, to select class field in JavaScript, writing `$FIELD = $INIT` will 
 
 We can also use an _object_ to specify a sub-syntax node to match within a larger context. It consists of an object with three properties: `context`, `selector` and `strictness`.
 
-* `context`: defines the surrounding code that helps to resolve any ambiguity in the syntax.
-* `selector`: defines the sub-syntax node kind that is the actual matcher of the pattern.
-* `strictness`: optional. defines how strictly pattern will match against nodes.
+* `context` (required): defines the surrounding code that helps to resolve any ambiguity in the syntax.
+* `selector` (optional):  defines the sub-syntax node kind that is the actual matcher of the pattern.
+* `strictness` (optional): defines how strictly pattern will match against nodes.
 
 Let's see how pattern object can solve the ambiguity in the class field example above.
 


### PR DESCRIPTION
Clearly distinguishing required and optional fields reduces confusion, prevents errors, accelerates onboarding for new developers, simplifies maintenance and expansion, and ensures seamless integration with a well-documented schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the guide to clearly specify that the "context" property is required and the "selector" property is optional when defining a sub-syntax node for pattern matching. The "strictness" property remains optional, improving clarity around the usage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->