### PR TITLE
Fix typo in pattern-syntax.md

### DIFF
--- a/website/guide/pattern-syntax.md
+++ b/website/guide/pattern-syntax.md
@@ -141,7 +141,7 @@ testFunc(1 + 1)
 testFunc(...args)
 ```
 
-Note in the example above, even if two meta variables have the same name `$_FUNC`, each occurrence of `$_FUNC` can match different content because the are not captured.
+Note in the example above, even if two meta variables have the same name `$_FUNC`, each occurrence of `$_FUNC` can match different content because they are not captured.
 
 :::info Why use non-capturing match?
 This is a useful trick to micro-optimize pattern matching speed, since we don't need to create a [HashMap](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html) for bookkeeping.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced clarity in the guide by correcting a grammatical error in the explanatory note on meta variables for pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->