### PR TITLE
docs: fix tree-sitter build command

### DIFF
--- a/website/contributing/add-lang.md
+++ b/website/contributing/add-lang.md
@@ -151,7 +151,7 @@ Then, in your parser repository, use this command to build a WASM file.
 
 ```bash
 tree-sitter generate # if grammar is not generated before
-tree-sitter build-wasm
+tree-sitter build --wasm
 ```
 
 Note you may need to install [docker](https://www.docker.com/) when building WASM files.


### PR DESCRIPTION
## description

fix tree-sitter build command

before:

`tree-sitter build-wasm`

after

`tree-sitter build --wasm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the instructions for building WebAssembly files by revising the command syntax to reflect the latest Tree-sitter tool usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->