### PR TITLE
Fix Python type: Int -> int

### DIFF
--- a/website/catalog/python/optional-to-none-union.md
+++ b/website/catalog/python/optional-to-none-union.md
@@ -24,14 +24,14 @@ fix: $T | None
 
 <!-- highlight matched code in curly-brace {lineNum} -->
 ```py {1}
-def a(arg: Optional[Int]): pass
+def a(arg: Optional[int]): pass
 ```
 
 ### Diff
 <!-- use // [!code --] and // [!code ++] to annotate diff -->
 ```py
-def a(arg: Optional[Int]): pass # [!code --]
-def a(arg: Int | None): pass # [!code ++]
+def a(arg: Optional[int]): pass # [!code --]
+def a(arg: int | None): pass # [!code ++]
 ```
 
 ### Contributed by


### PR DESCRIPTION
Thank you for the excellent tool and catalog.
Since the integer type in Python is `int` (lowercase), I will send this pull request.