### PR TITLE
Remove Shisho tool comparison from documentation

### DIFF
--- a/website/advanced/tool-comparison.md
+++ b/website/advanced/tool-comparison.md
@@ -72,15 +72,3 @@ IntelliJ Structural Search Replace is not a standalone tool, but a feature of th
 
 **Cons**:
 * Currently, IntelliJ IDEA supports the structural search and replace for Java, Kotlin and Groovy.
-
-## [Shisho](https://github.com/flatt-security/shisho)
-Shisho is a new and promising tool that uses code patterns to search and manipulate code in various languages.
-
-**Pros**:
-* It offers fast and flexible rule composition using code patterns.
-* It can handle multiple languages and files in parallel, and it has a simple and intuitive syntax for specifying patterns and filters.
-
-**Cons**:
-* It is still in development and it has limited language support compared to the other tools.
-It currently supports only 3 languages, while the other tools support over 20 languages.
-* The tool's parent company seems to have changed their business direction.


### PR DESCRIPTION
Shisho has been unmaintained for 4 years. 

I strongly encourage you to check on the information about the other tools as well, considering you critize them possibly for issues, they have solved for years. 

Does look better publicly for yourself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Shisho tool comparison section from advanced tools documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->