### PR TITLE
Fix syntax for overriding rule severity

### DIFF
--- a/website/guide/project/severity.md
+++ b/website/guide/project/severity.md
@@ -25,7 +25,7 @@ severity: error
 You can override the severity level of a rule on the command line. This is useful when you want to change the severity level of a rule for a specific scan.
 
 ```bash
-ast-grep scan --error rule-id --warning other-rule-id
+ast-grep scan --error=rule-id --warning=other-rule-id
 ```
 
 You can use multiple `--error`, `--warning`, `--info`, `--hint`, and `--off` flags to override multiple rules.
@@ -123,9 +123,9 @@ You can also override the severity level of the `unused-suppression` rule on the
 
 ```bash
 # treat unused directive as error, useful in CI/CD
-ast-grep scan --error unused-suppression
+ast-grep scan --error=unused-suppression
 # enable report even not all rules are enabled
-ast-grep --rule rule.yml scan --hint unused-suppression
+ast-grep --rule rule.yml scan --hint=unused-suppression
 ```
 
 ## Disallow Suppress-All Comments


### PR DESCRIPTION
If you invoke `ast-grep scan --error foo`, then `foo` will be
interpreted as a filename:

```bash
$ ast-grep scan --error unused-suppression
ERROR: unused-suppression: No such file or directory (os error 2)
```

Make the docs match `ast-grep scan --help` output, which requires
setting `--(error|warning|info|hint)` using `=`.

I think this was comprehensive
==============================
`git grep -E '\-\-(error|warning|info|hint|off) '` returns no entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI examples for overriding rule severity to use the `--error=...` and `--warning=...` syntax.
  * Adjusted examples for reporting unused suppressions to use the `--error=unused-suppression` and `--hint=unused-suppression` format.
  * Refined example output formatting in the severity inspection section for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->