### PR TITLE
docs: fix syntax error and invalid expandEnd in config cheatsheet

### DIFF
--- a/website/cheatsheet/yaml.md
+++ b/website/cheatsheet/yaml.md
@@ -77,7 +77,7 @@ rule:
 
 ```yaml
 constraints:
-  ARG: { kind: 'string' } }
+  ARG: { kind: 'string' }
 ```
 
 ⚙️ Additional `constraints` rules to filter meta-variable matches.
@@ -145,7 +145,7 @@ fix: "logger.log($$$ARGS)"
 ```yaml
 fix:
   template: "logger.log($$$ARGS)"
-  expandEnd: rule
+  expandEnd: { regex: ',' }
 ```
 
 🔧 Fix also accepts `FixConfig` object.


### PR DESCRIPTION
## Summary

This PR fixes two inaccuracies in the [Config Cheat Sheet](https://ast-grep.github.io/cheatsheet/yaml.html):

### 1. Syntax error in `constraints` example

**Before:**
```yaml
constraints:
  ARG: { kind: 'string' } }
```

**After:**
```yaml
constraints:
  ARG: { kind: 'string' }
```

The extra closing brace `}` made the YAML invalid.

### 2. Invalid `expandEnd` value in `FixConfig` example

**Before:**
```yaml
fix:
  template: "logger.log($$$ARGS)"
  expandEnd: rule
```

**After:**
```yaml
fix:
  template: "logger.log($$$ARGS)"
  expandEnd: { regex: ',' }
```

`expandEnd` expects a **rule object** (e.g., `{ regex: ',' }` or `{ kind: comma }`), not the bare string `rule`. Using `rule` as a value would cause ast-grep to reject the configuration.

Both fixes were verified against the [ast-grep YAML reference docs](https://ast-grep.github.io/reference/yaml.html) and the [FixConfig guide](https://ast-grep.github.io/guide/rewrite-code.html#expanding-the-match-range-with-fixconfig).

---

**Note:** I also reviewed the [Rule Cheat Sheet](https://ast-grep.github.io/cheatsheet/rule.html) against the official docs. The Rule Cheat Sheet is accurate; no changes were needed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the YAML cheatsheet’s “Finding” constraints example.
  * Updated the “Patching” example to show comma-based end expansion using a regular expression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->