### PR TITLE
Revert "fix: try switching back to ast-grep.github.io"

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -206,7 +206,7 @@ export default defineConfig({
   cleanUrls: true,
   lastUpdated: true,
   transformPageData(pageData) {
-    const canonicalUrl = `https://ast-grep.github.io/${pageData.relativePath}`
+    const canonicalUrl = `https://astgrep.com/${pageData.relativePath}`
       .replace(/index\.md$/, '')
       .replace(/\.md$/, '')
     pageData.frontmatter.head ??= []
@@ -285,6 +285,6 @@ export default defineConfig({
     },
   },
   sitemap: {
-    hostname: 'https://ast-grep.github.io',
+    hostname: 'https://astgrep.com',
   },
 })

--- a/website/advanced/find-n-patch.md
+++ b/website/advanced/find-n-patch.md
@@ -8,7 +8,7 @@ In this post, we will introduce a different approach to code transformation call
 
 This scheme lets you rewrite complex code using a fully declarative [Domain-Specific Language](https://www.wikiwand.com/en/Domain-specific_language) (DSL). While the scheme is powerful, the underlying concept is simple: find certain nodes, rewrite them, and recursively repeat the rewriting.
 
-The idea of Find & Patch comes from developing [ast-grep](https://ast-grep.github.io/), a tool using AST to find and replace code patterns. We realized that this approach can be generalized and extended to support more complex and diverse code transformations!
+The idea of Find & Patch comes from developing [ast-grep](https://astgrep.com/), a tool using AST to find and replace code patterns. We realized that this approach can be generalized and extended to support more complex and diverse code transformations!
 
 At the end of this article, we will compare Find & Patch to functional programming on the tree of syntax nodes. You can apply filter nodes using `rule`, map them via `transform`, and compose them with `rewriters`.
 

--- a/website/advanced/prompting.md
+++ b/website/advanced/prompting.md
@@ -47,7 +47,7 @@ Large Language Models (LLMs) with extensive context windows can be made highly e
 
 The `llms.txt` file for ast-grep is a compilation of the entire documentation, designed to be fed into an LLM's context. This method significantly reduces the likelihood of the model "hallucinating" or generating incorrect ast-grep rules by giving it a thorough and accurate knowledge base to draw from.
 
-You can find the full `llms.txt` file here: [https://ast-grep.github.io/llms-full.txt](/llms-full.txt)
+You can find the full `llms.txt` file here: [https://astgrep.com/llms-full.txt](/llms-full.txt)
 
 By loading this text into your session with a capable LLM, you can ask more complex questions and receive more accurate and nuanced answers regarding ast-grep's features and usage.
 

--- a/website/blog/ast-grep-agent.md
+++ b/website/blog/ast-grep-agent.md
@@ -11,7 +11,7 @@ head:
       content: ast-grep's Journey to AI Generated Rules
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/ast-grep-agent
+      content: https://astgrep.com/blog/ast-grep-agent
   - - meta
     - property: og:description
       content: Advancements in AI have made it possible to generate ast-grep rules with a well-written prompt.

--- a/website/blog/ast-grep-outline.md
+++ b/website/blog/ast-grep-outline.md
@@ -11,7 +11,7 @@ head:
       content: Introducing ast-grep Outline
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/ast-grep-outline
+      content: https://astgrep.com/blog/ast-grep-outline
   - - meta
     - property: og:description
       content: ast-grep Outline gives humans and coding agents a fast, syntax-aware table of contents for source code without building an index.

--- a/website/blog/code-search-design-space.md
+++ b/website/blog/code-search-design-space.md
@@ -11,13 +11,13 @@ head:
       content: Design Space for Code Search Query
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/code-search-design-space
+      content: https://astgrep.com/blog/code-search-design-space
   - - meta
     - property: og:description
       content: A review of the design space for code search tools.
   - - meta
     - property: og:image
-      content: https://ast-grep.github.io/image/blog/query-design.png
+      content: https://astgrep.com/image/blog/query-design.png
 ---
 
 # Design Space for Code Search Query

--- a/website/blog/fearless-concurrency.md
+++ b/website/blog/fearless-concurrency.md
@@ -11,18 +11,18 @@ head:
       content: An Example of Rust's Fearless Concurrency
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/fearless-concurrency
+      content: https://astgrep.com/blog/fearless-concurrency
   - - meta
     - property: og:description
       content: ast-grep shows how Rust's fearless concurrency works in practice. Learn how to design concurrent systems in Rust and the trade-offs involved.
   - - meta
     - property: og:image
-      content: https://ast-grep.github.io/image/blog/concurrent.jpg
+      content: https://astgrep.com/image/blog/concurrent.jpg
 ---
 
 # An Example of Rust's Fearless Concurrency
 
-Rust is famous for its "fearless concurrency." It's a bold claim, but what does it actually *mean*? How does Rust let you write concurrent code without constantly battling race conditions? [ast-grep](https://ast-grep.github.io/)'s [recent refactor](https://github.com/ast-grep/ast-grep/discussions/1710) is a great example of Rust's concurrency model in action.
+Rust is famous for its "fearless concurrency." It's a bold claim, but what does it actually *mean*? How does Rust let you write concurrent code without constantly battling race conditions? [ast-grep](https://astgrep.com/)'s [recent refactor](https://github.com/ast-grep/ast-grep/discussions/1710) is a great example of Rust's concurrency model in action.
 
 ## Old Architecture of ast-grep's Printer
 

--- a/website/blog/how-to-debug.md
+++ b/website/blog/how-to-debug.md
@@ -11,7 +11,7 @@ head:
       content: How to Debug ast-grep Rule Effectively
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/how-to-debug
+      content: https://astgrep.com/blog/how-to-debug
   - - meta
     - property: og:description
       content: Learn how to debug ast-grep rules effectively by simplifying code and rules step by step.

--- a/website/blog/interactive-demo.md
+++ b/website/blog/interactive-demo.md
@@ -11,7 +11,7 @@ head:
       content: Interactive Code Fixes with Multiple Options!
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/interactive-demo
+      content: https://astgrep.com/blog/interactive-demo
   - - meta
     - property: og:description
       content: Today, we're thrilled to showcase a game-changing feature, multi-option interactive code fixes!

--- a/website/blog/mastering-ast-grep.md
+++ b/website/blog/mastering-ast-grep.md
@@ -11,7 +11,7 @@ head:
       content: 'Announcing the Book: Mastering ast-grep'
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/optimize-ast-grep
+      content: https://astgrep.com/blog/optimize-ast-grep
   - - meta
     - property: og:description
       content: Mastering ast-grep, a comprehensive guide designed to bridge the gap between basic tool reference and advanced structural search mastery.

--- a/website/blog/migrate-bevy.md
+++ b/website/blog/migrate-bevy.md
@@ -11,7 +11,7 @@ head:
       content: Migrating Bevy can be easier with (semi-)automation
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/migrate-bevy
+      content: https://astgrep.com/blog/migrate-bevy
   - - meta
     - property: og:description
       content: In this article, we will show you how to make migration easier by using some command line tools.

--- a/website/blog/more-llm-support.md
+++ b/website/blog/more-llm-support.md
@@ -12,7 +12,7 @@ head:
       content: ast-grep gets more LLM support!
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/more-llm-support
+      content: https://astgrep.com/blog/more-llm-support
   - - meta
     - property: og:description
       content: ast-grep is getting even better with enhanced Large Language Model (LLM) support. This exciting development opens up new possibilities for developers to analyze, understand, and transform code more efficiently. Let's dive into the details of these new features.
@@ -40,7 +40,7 @@ On the other hand, ast-grep faces challenges due to the limited training data av
 
 The general usage of `llms.txt` is as follows:
 
-1. Visit [https://ast-grep.github.io/llms-full.txt](https://ast-grep.github.io/llms-full.txt) and copy the full documentation text
+1. Visit [https://astgrep.com/llms-full.txt](https://astgrep.com/llms-full.txt) and copy the full documentation text
 2. Paste these documents into your conversation with your preferred AI chatbot
 3. Ask AI questions about ast-grep
 

--- a/website/blog/new-ver-38.md
+++ b/website/blog/new-ver-38.md
@@ -12,7 +12,7 @@ head:
       content: ast-grep new release 0.38
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/new-ver-38
+      content: https://astgrep.com/blog/new-ver-38
   - - meta
     - property: og:description
       content: ast-grep 0.38 brings some fantastic new features to improve your code searching and linting experience, alongside a significant internal shift.
@@ -84,7 +84,7 @@ These changes are part of the larger effort to decouple ast-grep from tree-sitte
 
 We believe these changes, especially the move towards parser independence and the enhanced diagnostic labeling, will make ast-grep an even more powerful and user-friendly tool for your everyday development tasks.
 
-Head over to our [GitHub repo](https://github.com/ast-grep/ast-grep)  to grab the latest version. Check out the [documentation](https://ast-grep.github.io/) for more details on how to use the new features.
+Head over to our [GitHub repo](https://github.com/ast-grep/ast-grep)  to grab the latest version. Check out the [documentation](https://astgrep.com/) for more details on how to use the new features.
 
 We're excited to see how you use ast-grep 0.38! As always, your feedback is invaluable, so please don't hesitate to open issues or discussions on our GitHub repository.
 

--- a/website/blog/new-ver-39.md
+++ b/website/blog/new-ver-39.md
@@ -12,7 +12,7 @@ head:
       content: ast-grep new release 0.39
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/new-ver-39
+      content: https://astgrep.com/blog/new-ver-39
   - - meta
     - property: og:description
       content: 'ast-grep 0.39 includes new languages support, better file config and Esquery style kind.'

--- a/website/blog/new-ver-42.md
+++ b/website/blog/new-ver-42.md
@@ -12,7 +12,7 @@ head:
       content: ast-grep 0.42 - The Answer to Code Searching
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/new-ver-42
+      content: https://astgrep.com/blog/new-ver-42
   - - meta
     - property: og:description
       content: 'ast-grep 0.42: parameterized utilities, ESQuery-style selectors, and improved LSP diagnostics for injected languages.'

--- a/website/blog/new-ver-43.md
+++ b/website/blog/new-ver-43.md
@@ -12,7 +12,7 @@ head:
       content: ast-grep 0.43 - Search Code and Markdown with Structure
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/new-ver-43
+      content: https://astgrep.com/blog/new-ver-43
   - - meta
     - property: og:description
       content: 'ast-grep 0.43 adds Markdown support and brings ESQuery-style selectors to the run command for fast structural queries from the CLI.'

--- a/website/blog/optimize-ast-grep.md
+++ b/website/blog/optimize-ast-grep.md
@@ -11,7 +11,7 @@ head:
       content: Optimize ast-grep to get 10X faster
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/optimize-ast-grep
+      content: https://astgrep.com/blog/optimize-ast-grep
   - - meta
     - property: og:description
       content: How to optimize the Rust CLI tool ast-grep to become 10 times faster.
@@ -19,7 +19,7 @@ head:
 
 # Optimize ast-grep to get 10X faster
 
-In this post I will discuss how to optimize the Rust CLI tool [ast-grep](https://ast-grep.github.io/) to become 10 times faster.
+In this post I will discuss how to optimize the Rust CLI tool [ast-grep](https://astgrep.com/) to become 10 times faster.
 
 Rust itself usually runs fast enough, but it is not a silver bullet to all performance issues.
 
@@ -27,7 +27,7 @@ In this case, I did not pay enough attention to runtime details or opted for nai
 
 # Context
 
-[ast-grep](https://ast-grep.github.io/) is [my](https://github.com/HerringtonDarkholme) hobby project to help you search and rewrite code using [abstract syntax tree](https://www.wikiwand.com/en/Abstract_syntax_tree).
+[ast-grep](https://astgrep.com/) is [my](https://github.com/HerringtonDarkholme) hobby project to help you search and rewrite code using [abstract syntax tree](https://www.wikiwand.com/en/Abstract_syntax_tree).
 
 Conceptually, ast-grep takes a piece of pattern code (think it like a regular expression but for AST), matches the pattern against your codebase and gives a list of matched AST nodes back to you. See the [playground](/playground) for a live demo.
 

--- a/website/blog/stars-3000.md
+++ b/website/blog/stars-3000.md
@@ -12,7 +12,7 @@ head:
       content: ast-grep got 3000 stars!
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/stars-3000
+      content: https://astgrep.com/blog/stars-3000
   - - meta
     - property: og:description
       content: ast-grep has recently reached 3000 stars on GitHub! This is a remarkable achievement for the project and I am deeply grateful for all the support and feedback that I have received from the open source community.
@@ -26,7 +26,7 @@ I am very excited and thankful to share with you that ast-grep, a code search an
 
 ## What is ast-grep?
 
-[ast-grep](https://ast-grep.github.io) is a tool that allows you to search and transform code using abstract syntax trees (ASTs). ASTs are tree-like representations of the structure and meaning of source code. By using ASTs, ast-grep can perform more accurate and powerful operations than regular expressions or plain text search.
+[ast-grep](https://astgrep.com) is a tool that allows you to search and transform code using abstract syntax trees (ASTs). ASTs are tree-like representations of the structure and meaning of source code. By using ASTs, ast-grep can perform more accurate and powerful operations than regular expressions or plain text search.
 
 ast-grep supports multiple programming languages, such as JavaScript, [TypeScript](/catalog/typescript/), Python, [Ruby](/catalog/ruby/), Java, C#, [Rust](/catalog/rust/), and more. You can write [patterns](/guide/pattern-syntax) and rules in [YAML](/guide/rule-config/atomic-rule) format to specify what you want to match and how you want to transform it. You can also use the command-line interface (CLI) or the web-based [playground](/playground) to run ast-grep on your code.
 
@@ -67,7 +67,7 @@ ast-grep has many plans and goals for the future to make it more useful and user
 
 ## How to get involved?
 
-If you are interested in ast-grep and want to try it out, you can install it from [npm](https://www.npmjs.com/package/@ast-grep/cli) or [GitHub](https://github.com/ast-grep/ast-grep). You can also visit the [website](https://ast-grep.github.io/) to learn more about the features, documentation, and examples of ast-grep.
+If you are interested in ast-grep and want to try it out, you can install it from [npm](https://www.npmjs.com/package/@ast-grep/cli) or [GitHub](https://github.com/ast-grep/ast-grep). You can also visit the [website](https://astgrep.com/) to learn more about the features, documentation, and examples of ast-grep.
 
 If you want to contribute to the code or documentation of ast-grep, we have prepared a thorough [contribution guide](/contributing/how-to) for you! You can also report issues, suggest features, or ask questions on the issue tracker.
 

--- a/website/blog/stars-5000.md
+++ b/website/blog/stars-5000.md
@@ -12,7 +12,7 @@ head:
       content: 'ast-grep: 5000 stars and beyond!'
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/stars-5000
+      content: https://astgrep.com/blog/stars-5000
   - - meta
     - property: og:description
       content: ast-grep has recently reached 5000 stars on GitHub! This is a remarkable achievement for the project and I am deeply grateful for all the support and feedback that I have received from the open source community.
@@ -27,7 +27,7 @@ We are thrilled to announce that ast-grep has reached 5000 stars on [GitHub](htt
 
 ## Why ast-grep?
 
-[ast-grep](https://ast-grep.github.io/) is a tool that allows you to search and transform code using abstract syntax trees (ASTs). ASTs are tree-like representations of the structure and meaning of source code. By using ASTs, ast-grep can perform more accurate and powerful operations than regular expressions or plain text search.
+[ast-grep](https://astgrep.com/) is a tool that allows you to search and transform code using abstract syntax trees (ASTs). ASTs are tree-like representations of the structure and meaning of source code. By using ASTs, ast-grep can perform more accurate and powerful operations than regular expressions or plain text search.
 
 We have introduced a lot of new features in the past few months, and we want to share them with you. We hope that you will find them useful and that they will help you write better code.
 

--- a/website/blog/stars-6000.md
+++ b/website/blog/stars-6000.md
@@ -12,7 +12,7 @@ head:
       content: ast-grep got 6000 stars!
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/stars-6000
+      content: https://astgrep.com/blog/stars-6000
   - - meta
     - property: og:description
       content: ast-grep has recently reached 6000 stars on GitHub! This is a remarkable achievement for the project and I am deeply grateful for all the support and feedback that I have received from the open source community.
@@ -20,7 +20,7 @@ head:
 
 # ast-grep got 6000 stars!
 
-We are thrilled to announce that [ast-grep](https://ast-grep.github.io/), the powerful code search tool, has reached a stellar milestone of 6000 stars on GitHub! This is a testament to the community's trust in our tool and the continuous improvements we've made. Let's dive into the latest features and enhancements that make ast-grep the go-to tool for developers worldwide.
+We are thrilled to announce that [ast-grep](https://astgrep.com/), the powerful code search tool, has reached a stellar milestone of 6000 stars on GitHub! This is a testament to the community's trust in our tool and the continuous improvements we've made. Let's dive into the latest features and enhancements that make ast-grep the go-to tool for developers worldwide.
 
 ![ast-grep 6k stars](/image/blog/stars-6k.png)
 

--- a/website/blog/stars-8000.md
+++ b/website/blog/stars-8000.md
@@ -12,7 +12,7 @@ head:
       content: ast-grep Rockets to 8000 Stars!
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/stars-8000
+      content: https://astgrep.com/blog/stars-8000
   - - meta
     - property: og:description
       content: ast-grep has recently reached 6000 stars on GitHub! This is a remarkable achievement for the project and I am deeply grateful for all the support and feedback that I have received from the open source community.
@@ -108,7 +108,7 @@ See [the youtube video](https://www.youtube.com/watch?v=oNbOoBhVL8o) for a live 
 
 ### Playground Power-Ups: Your Online Rule Lab
 
-The online playground at [https://ast-grep.github.io/](https://ast-grep.github.io/) is now an even more powerful lab for experimenting and refining your rules:
+The online playground at [https://astgrep.com/](https://astgrep.com/) is now an even more powerful lab for experimenting and refining your rules:
 
 **Parser Version Visibility:**  Small popups now display the tree-sitter version used in the playground, giving you valuable context for your rule testing.
 
@@ -136,7 +136,7 @@ Reaching over 8000 stars is an absolutely fantastic milestone, and it's all than
 
 **Get Started & Get Involved Today!**
 
-* **Explore the Enhanced Website:** Dive into the wealth of resources at [https://ast-grep.github.io/](https://ast-grep.github.io/)
+* **Explore the Enhanced Website:** Dive into the wealth of resources at [https://astgrep.com/](https://astgrep.com/)
 * **Star us on GitHub!** Show your support and help us reach the next milestone: [Star the GitHub Repo](https://github.com/ast-grep/ast-grep)
 * **Try out the New Features & Give Feedback:** Join the conversation on [Discord](https://discord.com/invite/4YZjf6htSQ) and tell us what you think!
 * **Contribute Rules to the Example Catalog:** Share your expertise and help others by [contributing rules](https://github.com/ast-grep/ast-grep.github.io/tree/main/website/catalog).

--- a/website/blog/tree-sitter-end-to-end.md
+++ b/website/blog/tree-sitter-end-to-end.md
@@ -11,7 +11,7 @@ head:
       content: Optimizing Tree-sitter for End-to-End ast-grep Performance
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/tree-sitter-end-to-end
+      content: https://astgrep.com/blog/tree-sitter-end-to-end
   - - meta
     - property: og:description
       content: Why a parser-only speedup made ast-grep slower, and how profiling virtual memory, arena growth, tree traversal, and the full application repaired it.

--- a/website/blog/tree-sitter-glr-arena.md
+++ b/website/blog/tree-sitter-glr-arena.md
@@ -11,7 +11,7 @@ head:
       content: Improving Tree-sitter's GLR Algorithm and Memory Layout
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/tree-sitter-glr-arena
+      content: https://astgrep.com/blog/tree-sitter-glr-arena
   - - meta
     - property: og:description
       content: How profiling Tree-sitter's GLR stack led to lazy graph materialization, compact arena-backed syntax nodes, and a long series of failed performance experiments.

--- a/website/blog/tree-sitter-rust-migration.md
+++ b/website/blog/tree-sitter-rust-migration.md
@@ -11,7 +11,7 @@ head:
       content: "Rewriting Tree-sitter's C Core in Rust: Migration and Compatibility"
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/tree-sitter-rust-migration
+      content: https://astgrep.com/blog/tree-sitter-rust-migration
   - - meta
     - property: og:description
       content: How an AI-assisted migration moved Tree-sitter's runtime from C to Rust while preserving its retained ABI, generated grammars, and external scanners.

--- a/website/blog/tree-sitter-rust-rewrite.md
+++ b/website/blog/tree-sitter-rust-rewrite.md
@@ -11,7 +11,7 @@ head:
       content: How ast-grep Rewrote Tree-sitter in Rust and Made It 30% Faster
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/tree-sitter-rust-rewrite
+      content: https://astgrep.com/blog/tree-sitter-rust-rewrite
   - - meta
     - property: og:description
       content: The complete adventure of using AI to rewrite Tree-sitter's C core in Rust, simplify it, optimize it, and discover that a faster parser could still make ast-grep slower.

--- a/website/blog/typed-napi.md
+++ b/website/blog/typed-napi.md
@@ -12,13 +12,13 @@ head:
       content: ast-grep's Journey to Type Safety in Node API
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/typed-napi
+      content: https://astgrep.com/blog/typed-napi
   - - meta
     - property: og:description
       content: ast-grep/napi now supports typed AST manipulation which is correct, concise, robust, and performant.
   - - meta
     - property: og:image
-      content: https://ast-grep.github.io/image/blog/napi.jpg
+      content: https://astgrep.com/image/blog/napi.jpg
 ---
 
 # ast-grep's Journey to Type Safety in Node API

--- a/website/blog/yaml-vs-dsl.md
+++ b/website/blog/yaml-vs-dsl.md
@@ -12,7 +12,7 @@ head:
       content: 'YAML vs DSL: comparison is subjective'
   - - meta
     - property: og:url
-      content: https://ast-grep.github.io/blog/yaml-vs-dsl
+      content: https://astgrep.com/blog/yaml-vs-dsl
   - - meta
     - property: og:description
       content: YAML and DSL are two different approaches to configure rule in structural search. The question "which is better" is largely subjective.
@@ -220,4 +220,4 @@ Consider these points when you want to have objective comparison:
 * Integration with API, how you bring type-safe DSL into your general purpose programming language, like [graphql](https://github.com/Quramy/ts-graphql-plugin) and [styled component](https://github.com/styled-components/typescript-styled-plugin).
 * Broader ecosystem support, such as GitHub language detection, AI support, etc.
 
-If you are going to use native tooling in your JavaScript/TypeScript project, I recommend you to use [oxlint](https://oxc.rs/) and, if you need simple custom rules, [ast-grep](https://ast-grep.github.io/).
+If you are going to use native tooling in your JavaScript/TypeScript project, I recommend you to use [oxlint](https://oxc.rs/) and, if you need simple custom rules, [ast-grep](https://astgrep.com/).

--- a/website/catalog/c/match-function-call.md
+++ b/website/catalog/c/match-function-call.md
@@ -7,7 +7,7 @@
 One of the common questions of ast-grep is to match function calls in C.
 
 A plain pattern like `test($A)` will not work. This is because [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c)
-parse the code snippet into `macro_type_specifier`, see the [pattern output](https://ast-grep.github.io/playground#eyJtb2RlIjoiUGF0Y2giLCJsYW5nIjoiYyIsInF1ZXJ5IjoidGVzdCgkJCQpIiwicmV3cml0ZSI6IiIsImNvbmZpZyI6InJ1bGU6XG4gIHBhdHRlcm46IFxuICAgIGNvbnRleHQ6ICRNKCQkJCk7XG4gICAgc2VsZWN0b3I6IGNhbGxfZXhwcmVzc2lvbiIsInNvdXJjZSI6IiNkZWZpbmUgdGVzdCh4KSAoMip4KVxuaW50IGEgPSB0ZXN0KDIpO1xuaW50IG1haW4oKXtcbiAgICBpbnQgYiA9IHRlc3QoMik7XG59In0=).
+parse the code snippet into `macro_type_specifier`, see the [pattern output](https://astgrep.com/playground#eyJtb2RlIjoiUGF0Y2giLCJsYW5nIjoiYyIsInF1ZXJ5IjoidGVzdCgkJCQpIiwicmV3cml0ZSI6IiIsImNvbmZpZyI6InJ1bGU6XG4gIHBhdHRlcm46IFxuICAgIGNvbnRleHQ6ICRNKCQkJCk7XG4gICAgc2VsZWN0b3I6IGNhbGxfZXhwcmVzc2lvbiIsInNvdXJjZSI6IiNkZWZpbmUgdGVzdCh4KSAoMip4KVxuaW50IGEgPSB0ZXN0KDIpO1xuaW50IG1haW4oKXtcbiAgICBpbnQgYiA9IHRlc3QoMik7XG59In0=).
 
 To avoid this ambiguity, ast-grep lets us write a [contextual pattern](/guide/rule-config/atomic-rule#pattern), which is a pattern inside a larger code snippet.
 We can use `context` to write a pattern like this: `test($A);`. Then, we can use the selector `call_expression` to match only function calls.

--- a/website/guide/rule-config.md
+++ b/website/guide/rule-config.md
@@ -136,7 +136,7 @@ interface Pattern {
   strictness?: Strictness
 }
 
-// See https://ast-grep.github.io/advanced/match-algorithm
+// See https://astgrep.com/advanced/match-algorithm
 type Strictness =
   | 'cst'
   | 'smart'

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+astgrep.com

--- a/website/public/schema.json
+++ b/website/public/schema.json
@@ -29,7 +29,7 @@
       }
     },
     "transform": {
-      "description": "A dictionary for metavariable manipulation. Dict key is the new variable name.\nDict value is a [transformation] that specifies how meta var is processed.\nSee [transformation doc](https://ast-grep.github.io/reference/yaml/transformation).",
+      "description": "A dictionary for metavariable manipulation. Dict key is the new variable name.\nDict value is a [transformation] that specifies how meta var is processed.\nSee [transformation doc](https://astgrep.com/reference/yaml/transformation).",
       "type": [
         "object",
         "null"
@@ -39,7 +39,7 @@
       }
     },
     "fix": {
-      "description": "A pattern string or a FixConfig object to auto fix the issue.\nIt can reference metavariables appeared in rule.\nSee details in fix [object reference](https://ast-grep.github.io/reference/yaml/fix#fixconfig).",
+      "description": "A pattern string or a FixConfig object to auto fix the issue.\nIt can reference metavariables appeared in rule.\nSee details in fix [object reference](https://astgrep.com/reference/yaml/fix#fixconfig).",
       "anyOf": [
         {
           "$ref": "#/$defs/SerializableFixer"
@@ -722,7 +722,7 @@
           }
         },
         "transform": {
-          "description": "A dictionary for metavariable manipulation. Dict key is the new variable name.\nDict value is a [transformation] that specifies how meta var is processed.\nSee [transformation doc](https://ast-grep.github.io/reference/yaml/transformation).",
+          "description": "A dictionary for metavariable manipulation. Dict key is the new variable name.\nDict value is a [transformation] that specifies how meta var is processed.\nSee [transformation doc](https://astgrep.com/reference/yaml/transformation).",
           "type": [
             "object",
             "null"
@@ -732,7 +732,7 @@
           }
         },
         "fix": {
-          "description": "A pattern string or a FixConfig object to auto fix the issue.\nIt can reference metavariables appeared in rule.\nSee details in fix [object reference](https://ast-grep.github.io/reference/yaml/fix#fixconfig).",
+          "description": "A pattern string or a FixConfig object to auto fix the issue.\nIt can reference metavariables appeared in rule.\nSee details in fix [object reference](https://astgrep.com/reference/yaml/fix#fixconfig).",
           "anyOf": [
             {
               "$ref": "#/$defs/SerializableFixer"

--- a/website/reference/cli/run.md
+++ b/website/reference/cli/run.md
@@ -34,7 +34,7 @@ String to replace the matched AST node
 
 ### `-l, --lang <LANG>`
 
-The language of the pattern. For full language list, visit https://ast-grep.github.io/reference/languages
+The language of the pattern. For full language list, visit https://astgrep.com/reference/languages
 
 ### `--debug-query[=<format>]`
 
@@ -50,7 +50,7 @@ Possible values:
 
 AST kind to extract sub-part of pattern to match.
 
-selector defines the sub-syntax node kind that is the actual matcher of the pattern. See https://ast-grep.github.io/guide/rule-config/atomic-rule#pattern-object.
+selector defines the sub-syntax node kind that is the actual matcher of the pattern. See https://astgrep.com/guide/rule-config/atomic-rule#pattern-object.
 
 ### `-k, --kind <KIND>`
 

--- a/website/reference/yaml.md
+++ b/website/reference/yaml.md
@@ -331,7 +331,7 @@ Documentation link to this rule. It will be displayed in editor extension if sup
 **Example:**
 
 ```yaml
-url: 'https://ast-grep.github.io/catalog/python/#migrate-openai-sdk'
+url: 'https://astgrep.com/catalog/python/#migrate-openai-sdk'
 ```
 
 ### `metadata`

--- a/website/src/components/PatternConfig.vue
+++ b/website/src/components/PatternConfig.vue
@@ -13,7 +13,7 @@ function selectAll(e: FocusEvent) {
 <template>
   <div class="pattern-config">
     <label title="Strictness determines how the pattern is matched against the code.">
-      <a target="_blank" href="https://ast-grep.github.io/advanced/match-algorithm">ⓘ</a>
+      <a target="_blank" href="https://astgrep.com/advanced/match-algorithm">ⓘ</a>
       Strictness:
       <select class="strictness-select" v-model="strictness">
         <option value="smart">Smart</option>
@@ -25,7 +25,7 @@ function selectAll(e: FocusEvent) {
       <IconDown/>
     </label>
     <label title="Selector is used to extract effective matcher from pattern.">
-      <a target="_blank" href="https://ast-grep.github.io/advanced/faq#my-pattern-does-not-work-why">ⓘ</a>
+      <a target="_blank" href="https://astgrep.com/advanced/faq#my-pattern-does-not-work-why">ⓘ</a>
       Selector:
       <input @focus="selectAll" class="selector-input" type="text" v-model="selector"/>
     </label>

--- a/website/src/components/PatternEditor.vue
+++ b/website/src/components/PatternEditor.vue
@@ -71,7 +71,7 @@ function changeFocusNode(e: any) {
           :language="language"
           :highlights="highlights"/>
         <p class="pattern-separator">
-          <a target="_blank" href="https://ast-grep.github.io/guide/rewrite-code">ⓘ</a>
+          <a target="_blank" href="https://astgrep.com/guide/rewrite-code">ⓘ</a>
           Rewrite
         </p>
         <Monaco

--- a/website/src/components/QueryEditor.vue
+++ b/website/src/components/QueryEditor.vue
@@ -72,7 +72,7 @@ let showFullTree = shallowRef(false)
       <label class="tree-toggle-label" title="Show unnamed nodes in CST">
         <input class="tree-toggle" type="checkbox" v-model="showFullTree">
         Show Full Tree
-        <a target="_blank" href="https://ast-grep.github.io/advanced/core-concepts">ⓘ</a>
+        <a target="_blank" href="https://astgrep.com/advanced/core-concepts">ⓘ</a>
       </label>
     </template>
     <template #panel>

--- a/website/src/components/astGrep/state.ts
+++ b/website/src/components/astGrep/state.ts
@@ -48,7 +48,7 @@ const query = 'console.log($MATCH)'
 const rewrite = 'logger.log($MATCH)'
 const config = `
 # YAML Rule is more powerful!
-# https://ast-grep.github.io/guide/rule-config#rule
+# https://astgrep.com/guide/rule-config#rule
 rule:
   any:
     - pattern: console.log($A)


### PR DESCRIPTION
This reverts commit ab9ec13cd5c4333c5c0de17029ba84e0a4e1725a.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated website, blog, reference, and schema links to use the `astgrep.com` domain.
  * Refreshed canonical URLs, social sharing metadata, and documentation examples.
  * Updated interactive editor links and default configuration references.
* **Website**
  * Configured `astgrep.com` as the primary website domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->