### PR TITLE
fix: fix unnecessary react hook to capture member expression hooks

### DIFF
--- a/website/catalog/tsx/unnecessary-react-hook.md
+++ b/website/catalog/tsx/unnecessary-react-hook.md
@@ -18,8 +18,15 @@ utils:
   hook_call:
     has:
       kind: call_expression
-      regex: ^use
       stopBy: end
+      has:
+        any:
+          - kind: identifier
+            regex: ^use
+          - kind: member_expression
+            has:
+              field: property
+              regex: ^use
 rule:
   any:
   - pattern: function $FUNC($$$) { $$$ }


### PR DESCRIPTION
This sample rule didn't capture hooks that already had nested hooks, but with member expressions. specially the common case of namespace imports of React like `React.useEffect`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of unnecessary React hook calls, including hooks accessed through object properties.
  * Ensured complete hook call expressions are analyzed for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->