### PR TITLE
docs: add WebAssembly API guide

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -63,6 +63,7 @@ const sidebar: DefaultTheme.Sidebar = [
         items: [
           { text: 'JavaScript API', link: '/guide/api-usage/js-api' },
           { text: 'Python API', link: '/guide/api-usage/py-api' },
+          { text: 'WebAssembly API', link: '/guide/api-usage/wasm-api' },
           { text: 'Performance Tip', link: '/guide/api-usage/performance-tip' },
         ],
       },

--- a/website/guide/api-usage.md
+++ b/website/guide/api-usage.md
@@ -19,11 +19,15 @@ Applying ast-grep's `fix` using JS/Python API is still experimental. See [this i
 
 ## Language Bindings
 
-ast-grep provides support for these programming languages:
+ast-grep provides these language bindings and runtimes:
 
 - **JavaScript:** Powered by napi.rs, ast-grep's JavaScript API is the most robust and reliable. [Explore JavaScript API](/guide/api-usage/js-api)
 
 - **Python:** ast-grep's PyO3 interface is the latest addition to climb the syntax tree! [Discover Python API](/guide/api-usage/py-api)
+
+- **WebAssembly:** `@ast-grep/wasm` provides the JavaScript API in browsers,
+  Deno, edge runtimes, and other WebAssembly environments. [Explore WebAssembly
+  API](/guide/api-usage/wasm-api)
 
 - **Rust:** ast-grep's Rust API is the most efficient way, but also the most challenging way, to use ast-grep. You can refer to [ast_grep_core](https://docs.rs/ast-grep-core/latest/ast_grep_core/) if you are familiar with Rust.
 

--- a/website/guide/api-usage.md
+++ b/website/guide/api-usage.md
@@ -25,9 +25,8 @@ ast-grep provides these language bindings and runtimes:
 
 - **Python:** ast-grep's PyO3 interface is the latest addition to climb the syntax tree! [Discover Python API](/guide/api-usage/py-api)
 
-- **WebAssembly:** `@ast-grep/wasm` provides the JavaScript API in browsers,
-  Deno, edge runtimes, and other WebAssembly environments. [Explore WebAssembly
-  API](/guide/api-usage/wasm-api)
+- **WebAssembly:** `@ast-grep/wasm` provides the JavaScript API in browsers and
+  other WebAssembly environments. [Explore WebAssembly API](/guide/api-usage/wasm-api)
 
 - **Rust:** ast-grep's Rust API is the most efficient way, but also the most challenging way, to use ast-grep. You can refer to [ast_grep_core](https://docs.rs/ast-grep-core/latest/ast_grep_core/) if you are familiar with Rust.
 

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -81,7 +81,9 @@ interface PatternTree {
 
 `initializeTreeSitter` initializes the shared runtime.
 `registerDynamicLanguage` loads language parsers. The remaining functions can
-be used after their language has been registered.
+be used after their language has been registered. Registration can be called
+again to add or update languages. `expandoChar` defaults to `$`; set another
+character for languages where `$` is valid syntax.
 
 ## Core Concepts
 
@@ -333,37 +335,6 @@ const edit = node.replace("console.error('bye world')")
 const newSource = root.commitEdits([edit])
 // "console.error('bye world')"
 ```
-
-## Use Other Language
-
-Unlike `@ast-grep/napi`, the WASM package does not ship with any predefined
-language parser. Call `initializeTreeSitter` once, then use
-`registerDynamicLanguage` before calling `parse`, `kind`, `pattern`, or
-`dumpPattern` for a language.
-
-```js
-import {
-  initializeTreeSitter,
-  registerDynamicLanguage,
-} from '@ast-grep/wasm'
-
-await initializeTreeSitter()
-
-await registerDynamicLanguage({
-  javascript: {
-    libraryPath: '/path/to/tree-sitter-javascript.wasm',
-  },
-  python: {
-    libraryPath: '/path/to/tree-sitter-python.wasm',
-    expandoChar: 'µ',
-  },
-})
-```
-
-`registerDynamicLanguage` accepts a map of language names to parser settings.
-It can be called multiple times to add or update languages. `expandoChar`
-defaults to `$`; choose another character for languages where `$` is valid
-syntax.
 
 For the implementation and package-level reference, see the
 [`@ast-grep/wasm` source](https://github.com/ast-grep/ast-grep/tree/main/crates/wasm).

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -5,6 +5,11 @@ runtimes, and other environments that support WebAssembly. Its API follows
 `@ast-grep/napi`, but uses `web-tree-sitter` and dynamically loaded WASM
 parsers.
 
+For a real-world example, see the
+[rust-beautifier repository](https://github.com/HerringtonDarkholme/rust-beautifier),
+try the [live demo](https://rust-beautifier.vercel.app), or inspect its
+[WASM-powered Rust transformer](https://github.com/HerringtonDarkholme/rust-beautifier/blob/main/app/lib/rust-transformer.ts).
+
 ## Installation
 
 Install the package and its `web-tree-sitter` peer dependency:

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -116,6 +116,7 @@ await registerDynamicLanguage({
   },
   python: {
     libraryPath: '/path/to/tree-sitter-python.wasm',
+    // set expandoChar since $ is not valid identifier in Py
     expandoChar: 'µ',
   },
 })

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -113,6 +113,7 @@ await initializeTreeSitter()
 await registerDynamicLanguage({
   javascript: {
     libraryPath: '/path/to/tree-sitter-javascript.wasm',
+    expandoChar: 'µ',
   },
 })
 

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -82,8 +82,10 @@ interface PatternTree {
 `initializeTreeSitter` initializes the shared runtime.
 `registerDynamicLanguage` loads language parsers. The remaining functions can
 be used after their language has been registered. Registration can be called
-again to add or update languages. `expandoChar` defaults to `$`; set another
-character for languages where `$` is valid syntax.
+again to add or update languages. The
+[`expandoChar`](/advanced/custom-language#register-language-in-sgconfig-yml)
+option defaults to `$`; set another character for languages where `$` is valid
+syntax.
 
 ## Core Concepts
 

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -301,19 +301,12 @@ class SgNode {
   nextAll(): Array<SgNode>
   prev(): SgNode | undefined
   prevAll(): Array<SgNode>
-  /** @deprecated Use children() instead. */
-  children_nodes(): Array<SgNode>
-  /** @deprecated Use parent() instead. */
-  parent_node(): SgNode | undefined
 }
 ```
 
 `children()` includes unnamed concrete-syntax-tree nodes such as operators and
 punctuation. `namedChildren()` returns only named AST nodes. `fieldChildren()`
 returns all children assigned to a named tree-sitter field.
-
-The older `children_nodes()` and `parent_node()` methods are deprecated aliases
-for `children()` and `parent()`.
 
 ## Fix code
 

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -2,8 +2,8 @@
 
 `@ast-grep/wasm` brings ast-grep's JavaScript API to browsers, Deno, edge
 runtimes, and other environments that support WebAssembly. Its API follows
-`@ast-grep/napi`, but it does not bundle language parsers. Register each
-tree-sitter WASM parser before using it.
+`@ast-grep/napi`, but uses `web-tree-sitter` and dynamically loaded WASM
+parsers.
 
 ## Installation
 
@@ -21,17 +21,81 @@ pnpm add @ast-grep/wasm web-tree-sitter
 
 :::
 
-Your application must serve the `tree-sitter.wasm` runtime and a WASM parser
-for every language it registers. For example, Vite applications can copy
-`node_modules/web-tree-sitter/tree-sitter.wasm` into `public` during
-installation. See the
+:::warning WASM setup
+The WASM package does not include predefined languages. Your application must
+serve the `tree-sitter.wasm` runtime and a tree-sitter WASM parser for every
+language it registers.
+:::
+
+For example, a Vite application can copy the tree-sitter runtime into `public`
+with a `postinstall` script:
+
+```json
+{
+  "scripts": {
+    "postinstall": "cp node_modules/web-tree-sitter/tree-sitter.wasm public"
+  }
+}
+```
+
+See the
 [`web-tree-sitter` setup guide](https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web#setup)
 for other environments.
 
-## Parse Code
+## Main Functions
 
-Initialize tree-sitter once, register the language parsers you need, and then
-parse source code:
+The package exports these top-level functions:
+
+```ts
+interface WasmLangInfo {
+  libraryPath: string
+  expandoChar?: string
+}
+
+function initializeTreeSitter(): Promise<void>
+function registerDynamicLanguage(
+  languages: Record<string, WasmLangInfo>,
+): Promise<void>
+function parse(lang: string, source: string): SgRoot
+function kind(lang: string, kindName: string): number
+function pattern(lang: string, pattern: string): object
+function dumpPattern(
+  lang: string,
+  pattern: string,
+  selector?: string,
+  strictness?: string,
+): PatternTree
+
+type PatternKind = 'terminal' | 'metaVar' | 'internal'
+
+interface PatternTree {
+  kind: string
+  pattern?: PatternKind
+  isNamed: boolean
+  text?: string
+  children: Array<PatternTree>
+  start: { line: number, column: number }
+  end: { line: number, column: number }
+}
+```
+
+`initializeTreeSitter` initializes the shared runtime.
+`registerDynamicLanguage` loads language parsers. The remaining functions can
+be used after their language has been registered.
+
+## Core Concepts
+
+The core concepts in the WebAssembly API are:
+
+* `SgRoot`: a class representing the whole syntax tree
+* `SgNode`: a node in the syntax tree
+
+A common workflow is:
+
+1. Initialize the tree-sitter WASM runtime once.
+2. Register each language's tree-sitter WASM parser.
+3. Parse source code and get its root `SgNode`.
+4. Search for nodes and inspect the results.
 
 ```js
 import {
@@ -44,35 +108,271 @@ await initializeTreeSitter()
 
 await registerDynamicLanguage({
   javascript: {
-    libraryPath: '/parsers/tree-sitter-javascript.wasm',
+    libraryPath: '/path/to/tree-sitter-javascript.wasm',
   },
 })
 
-const root = parse('javascript', 'console.log("hello")').root()
-const call = root.find('console.log($ARG)')
-call.getMatch('ARG').text() // "hello"
+const ast = parse('javascript', 'console.log("hello world")')
+const root = ast.root()
+const node = root.find('console.log($ARG)')
+node.getMatch('ARG').text() // "hello world"
 ```
 
-`registerDynamicLanguage` can register several languages in one call and can
-be called again to add or update registrations. Languages where `$` is valid
-syntax can also provide an `expandoChar`.
+### `SgRoot`
 
-## Traverse Named Children
+`SgRoot` represents the syntax tree of a source string.
 
-`children()` returns every direct concrete-syntax-tree child, including
-unnamed operators and punctuation. `namedChildren()` returns only named AST
-nodes:
+```ts
+class SgRoot {
+  root(): SgNode
+  filename(): string
+  getInnerTree(): Tree
+}
+```
+
+`root()` returns the root `SgNode`. `filename()` returns `"anonymous"` for
+trees created by `parse`. The WASM-specific `getInnerTree()` method exposes the
+underlying `web-tree-sitter` `Tree` for low-level inspection.
+
+### `SgNode`
+
+`SgNode` is the main interface for searching, inspecting, traversing, and
+rewriting the syntax tree.
 
 ```js
-const root = parse('javascript', 'a + b').root()
-const sum = root.find('$A + $B')
-
-sum.children().map(node => node.text()) // ['a', '+', 'b']
-sum.namedChildren().map(node => node.text()) // ['a', 'b']
+const log = root.find('console.log($A)')
+const arg = log.getMatch('A')
+arg.text() // "hello world"
 ```
 
-`namedChildren()` is available in `@ast-grep/wasm` 0.45.2 and later.
+## Search
 
-For the complete package API, including searching, relational matching, and
-rewriting, see the
-[`@ast-grep/wasm` API reference](https://github.com/ast-grep/ast-grep/tree/main/crates/wasm#api-reference).
+Use `find` and `findAll` to search for nodes in a syntax tree:
+
+```ts
+class SgNode {
+  find(matcher: Matcher): SgNode | undefined
+  findAll(matcher: Matcher): Array<SgNode>
+}
+```
+
+`find` returns the first matching node or `undefined`. `findAll` returns every
+matching node, or an empty array when there are no matches.
+
+```js
+const first = root.find('console.log($A)')
+const all = root.findAll('console.log($A)')
+```
+
+### Matcher
+
+A matcher can be a pattern string, a numeric kind ID, or a rule config object.
+
+```ts
+type Matcher = string | number | {
+  rule: object
+  constraints?: object
+  language?: string
+  transform?: object
+  utils?: object
+}
+```
+
+Use `kind` to look up a numeric kind ID, or `pattern` to build a pattern config:
+
+```js
+import { kind, pattern } from '@ast-grep/wasm'
+
+root.find('console.log($A)')
+root.find(kind('javascript', 'string'))
+root.find(pattern('javascript', 'console.log($A)'))
+
+root.find({
+  rule: { pattern: 'console.log($A)' },
+  constraints: {
+    A: { kind: 'string' },
+  },
+})
+```
+
+## Match
+
+Use these methods to read metavariables and transformed values from a match:
+
+```ts
+class SgNode {
+  getMatch(name: string): SgNode | undefined
+  getMultipleMatches(name: string): Array<SgNode>
+  getTransformed(name: string): string | undefined
+}
+```
+
+```js
+const source = `
+console.log('hello')
+logger('hello', 'world')
+`
+const root = parse('javascript', source).root()
+
+const log = root.find('console.log($A)')
+log.getMatch('A').text() // 'hello'
+
+const logger = root.find('logger($$$ARGS)')
+logger.getMultipleMatches('ARGS').map(node => node.text())
+// ["'hello'", ",", "'world'"]
+```
+
+## Inspection
+
+The following methods inspect a node:
+
+```ts
+class SgNode {
+  id(): number
+  range(): Range
+  isLeaf(): boolean
+  isNamed(): boolean
+  isNamedLeaf(): boolean
+  kind(): string
+  is(kind: string): boolean
+  text(): string
+}
+
+interface Range {
+  start: Pos
+  end: Pos
+}
+
+interface Pos {
+  line: number
+  column: number
+  index: number
+}
+```
+
+Position values are zero-indexed. In the WASM API, `index` is a character
+offset.
+
+For pattern debugging, `dumpPattern` returns the parsed pattern tree:
+
+```ts
+function dumpPattern(
+  lang: string,
+  pattern: string,
+  selector?: string,
+  strictness?: 'cst' | 'smart' | 'ast' | 'relaxed' | 'signature' | 'template',
+): PatternTree
+```
+
+The `PatternTree` shape is listed with the other
+[main functions](#main-functions).
+
+## Refinement
+
+Use refinement methods to test a node's relationship to a matcher:
+
+```ts
+class SgNode {
+  matches(matcher: Matcher): boolean
+  inside(matcher: Matcher): boolean
+  has(matcher: Matcher): boolean
+  precedes(matcher: Matcher): boolean
+  follows(matcher: Matcher): boolean
+}
+```
+
+```js
+const node = root.find('console.log($A)')
+node.matches('console.$METHOD($B)') // true
+```
+
+## Traversal
+
+Use the following methods to traverse the syntax tree:
+
+```ts
+class SgNode {
+  children(): Array<SgNode>
+  namedChildren(): Array<SgNode>
+  field(name: string): SgNode | undefined
+  fieldChildren(name: string): Array<SgNode>
+  parent(): SgNode | undefined
+  child(nth: number): SgNode | undefined
+  ancestors(): Array<SgNode>
+  next(): SgNode | undefined
+  nextAll(): Array<SgNode>
+  prev(): SgNode | undefined
+  prevAll(): Array<SgNode>
+  /** @deprecated Use children() instead. */
+  children_nodes(): Array<SgNode>
+  /** @deprecated Use parent() instead. */
+  parent_node(): SgNode | undefined
+}
+```
+
+`children()` includes unnamed concrete-syntax-tree nodes such as operators and
+punctuation. `namedChildren()` returns only named AST nodes. `fieldChildren()`
+returns all children assigned to a named tree-sitter field.
+
+The older `children_nodes()` and `parent_node()` methods are deprecated aliases
+for `children()` and `parent()`.
+
+## Fix code
+
+`SgNode` is immutable. Use `replace` to create an edit and `commitEdits` to
+apply edits and generate new source code:
+
+```ts
+interface WasmEdit {
+  start_pos: number
+  end_pos: number
+  inserted_text: string
+}
+
+class SgNode {
+  replace(text: string): WasmEdit
+  commitEdits(edits: Array<WasmEdit>): string
+}
+```
+
+```js
+const root = parse('javascript', "console.log('hello world')").root()
+const node = root.find('console.log($A)')
+const edit = node.replace("console.error('bye world')")
+const newSource = root.commitEdits([edit])
+// "console.error('bye world')"
+```
+
+## Use Other Language
+
+Unlike `@ast-grep/napi`, the WASM package does not ship with any predefined
+language parser. Call `initializeTreeSitter` once, then use
+`registerDynamicLanguage` before calling `parse`, `kind`, `pattern`, or
+`dumpPattern` for a language.
+
+```js
+import {
+  initializeTreeSitter,
+  registerDynamicLanguage,
+} from '@ast-grep/wasm'
+
+await initializeTreeSitter()
+
+await registerDynamicLanguage({
+  javascript: {
+    libraryPath: '/path/to/tree-sitter-javascript.wasm',
+  },
+  python: {
+    libraryPath: '/path/to/tree-sitter-python.wasm',
+    expandoChar: 'µ',
+  },
+})
+```
+
+`registerDynamicLanguage` accepts a map of language names to parser settings.
+It can be called multiple times to add or update languages. `expandoChar`
+defaults to `$`; choose another character for languages where `$` is valid
+syntax.
+
+For the implementation and package-level reference, see the
+[`@ast-grep/wasm` source](https://github.com/ast-grep/ast-grep/tree/main/crates/wasm).

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -84,8 +84,8 @@ interface PatternTree {
 be used after their language has been registered. Registration can be called
 again to add or update languages. The
 [`expandoChar`](/advanced/custom-language#register-language-in-sgconfig-yml)
-option defaults to `$`; set another character for languages where `$` is valid
-syntax.
+option defaults to `$`; set another character for languages where `$VAR` is not
+valid syntax.
 
 ## Core Concepts
 
@@ -113,6 +113,9 @@ await initializeTreeSitter()
 await registerDynamicLanguage({
   javascript: {
     libraryPath: '/path/to/tree-sitter-javascript.wasm',
+  },
+  python: {
+    libraryPath: '/path/to/tree-sitter-python.wasm',
     expandoChar: 'µ',
   },
 })

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -341,9 +341,10 @@ const newSource = root.commitEdits([edit])
 
 ## Live Example
 
-For a live example, see the
-[rust-beautifier repository](https://github.com/HerringtonDarkholme/rust-beautifier),
-try the [live demo](https://rust-beautifier.vercel.app), or inspect its
+For a live example, see
+[Parody](https://rust-beautifier.vercel.app)
+([context](https://x.com/hd_nvim/status/2094255500653134271?s=20),
+[repo](https://github.com/HerringtonDarkholme/rust-beautifier)), or inspect its
 [WASM-powered Rust transformer](https://github.com/HerringtonDarkholme/rust-beautifier/blob/main/app/lib/rust-transformer.ts).
 
 For the implementation and package-level reference, see the

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -339,6 +339,8 @@ const newSource = root.commitEdits([edit])
 // "console.error('bye world')"
 ```
 
+## Live Example
+
 For a live example, see the
 [rust-beautifier repository](https://github.com/HerringtonDarkholme/rust-beautifier),
 try the [live demo](https://rust-beautifier.vercel.app), or inspect its

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -125,14 +125,12 @@ node.getMatch('ARG').text() // "hello world"
 ```ts
 class SgRoot {
   root(): SgNode
-  filename(): string
   getInnerTree(): Tree
 }
 ```
 
-`root()` returns the root `SgNode`. `filename()` returns `"anonymous"` for
-trees created by `parse`. The WASM-specific `getInnerTree()` method exposes the
-underlying `web-tree-sitter` `Tree` for low-level inspection.
+`root()` returns the root `SgNode`. The WASM-specific `getInnerTree()` method
+exposes the underlying `web-tree-sitter` `Tree` for low-level inspection.
 
 ### `SgNode`
 

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -1,0 +1,78 @@
+# WebAssembly API
+
+`@ast-grep/wasm` brings ast-grep's JavaScript API to browsers, Deno, edge
+runtimes, and other environments that support WebAssembly. Its API follows
+`@ast-grep/napi`, but it does not bundle language parsers. Register each
+tree-sitter WASM parser before using it.
+
+## Installation
+
+Install the package and its `web-tree-sitter` peer dependency:
+
+::: code-group
+
+```bash [npm]
+npm install @ast-grep/wasm web-tree-sitter
+```
+
+```bash [pnpm]
+pnpm add @ast-grep/wasm web-tree-sitter
+```
+
+:::
+
+Your application must serve the `tree-sitter.wasm` runtime and a WASM parser
+for every language it registers. For example, Vite applications can copy
+`node_modules/web-tree-sitter/tree-sitter.wasm` into `public` during
+installation. See the
+[`web-tree-sitter` setup guide](https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web#setup)
+for other environments.
+
+## Parse Code
+
+Initialize tree-sitter once, register the language parsers you need, and then
+parse source code:
+
+```js
+import {
+  initializeTreeSitter,
+  parse,
+  registerDynamicLanguage,
+} from '@ast-grep/wasm'
+
+await initializeTreeSitter()
+
+await registerDynamicLanguage({
+  javascript: {
+    libraryPath: '/parsers/tree-sitter-javascript.wasm',
+  },
+})
+
+const root = parse('javascript', 'console.log("hello")').root()
+const call = root.find('console.log($ARG)')
+call.getMatch('ARG').text() // "hello"
+```
+
+`registerDynamicLanguage` can register several languages in one call and can
+be called again to add or update registrations. Languages where `$` is valid
+syntax can also provide an `expandoChar`.
+
+## Traverse Named Children
+
+`children()` returns every direct concrete-syntax-tree child, including
+unnamed operators and punctuation. `namedChildren()` returns only named AST
+nodes:
+
+```js
+const root = parse('javascript', 'a + b').root()
+const sum = root.find('$A + $B')
+
+sum.children().map(node => node.text()) // ['a', '+', 'b']
+sum.namedChildren().map(node => node.text()) // ['a', 'b']
+```
+
+`namedChildren()` is available in `@ast-grep/wasm` 0.45.2 and later.
+
+For the complete package API, including searching, relational matching, and
+rewriting, see the
+[`@ast-grep/wasm` API reference](https://github.com/ast-grep/ast-grep/tree/main/crates/wasm#api-reference).

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -341,10 +341,10 @@ const newSource = root.commitEdits([edit])
 
 ## Live Example
 
-For a live example, see
-[Parody](https://rust-beautifier.vercel.app)
-([context](https://x.com/hd_nvim/status/2094255500653134271?s=20),
-[repo](https://github.com/HerringtonDarkholme/rust-beautifier)), or inspect its
+For a live example, see this
+[parody](https://x.com/hd_nvim/status/2094255500653134271?s=20)
+[repo](https://github.com/HerringtonDarkholme/rust-beautifier), try the
+[live demo](https://rust-beautifier.vercel.app), and inspect its
 [WASM-powered Rust transformer](https://github.com/HerringtonDarkholme/rust-beautifier/blob/main/app/lib/rust-transformer.ts).
 
 For the implementation and package-level reference, see the

--- a/website/guide/api-usage/wasm-api.md
+++ b/website/guide/api-usage/wasm-api.md
@@ -5,11 +5,6 @@ runtimes, and other environments that support WebAssembly. Its API follows
 `@ast-grep/napi`, but uses `web-tree-sitter` and dynamically loaded WASM
 parsers.
 
-For a real-world example, see the
-[rust-beautifier repository](https://github.com/HerringtonDarkholme/rust-beautifier),
-try the [live demo](https://rust-beautifier.vercel.app), or inspect its
-[WASM-powered Rust transformer](https://github.com/HerringtonDarkholme/rust-beautifier/blob/main/app/lib/rust-transformer.ts).
-
 ## Installation
 
 Install the package and its `web-tree-sitter` peer dependency:
@@ -340,6 +335,11 @@ const edit = node.replace("console.error('bye world')")
 const newSource = root.commitEdits([edit])
 // "console.error('bye world')"
 ```
+
+For a live example, see the
+[rust-beautifier repository](https://github.com/HerringtonDarkholme/rust-beautifier),
+try the [live demo](https://rust-beautifier.vercel.app), or inspect its
+[WASM-powered Rust transformer](https://github.com/HerringtonDarkholme/rust-beautifier/blob/main/app/lib/rust-transformer.ts).
 
 For the implementation and package-level reference, see the
 [`@ast-grep/wasm` source](https://github.com/ast-grep/ast-grep/tree/main/crates/wasm).


### PR DESCRIPTION
## Summary

- add a consumer-facing guide for @ast-grep/wasm
- mirror the JavaScript and Python guide structure
- list the complete top-level, SgRoot, and SgNode API surfaces
- highlight WASM-specific runtime initialization, parser registration, and getInnerTree behavior
- link the guide from API usage and the sidebar

This is intentionally separate from #1053.

## Validation

- npm run build
- dprint check website/.vitepress/config.ts
- git diff --check main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebAssembly API documentation covering browser, Deno, and edge-runtime usage, installation, core functions, language registration, and code analysis workflows.
  * Added the WebAssembly API to the API Usage navigation.

* **Documentation**
  * Expanded language bindings guidance to include runtimes and WebAssembly support.
  * Added a live WebAssembly example and updated API reference details, including current language-registration behavior and supported workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->