### PR TITLE
feat: add grep link functionality to rules and implement codemod grep link generator

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -1,5 +1,6 @@
 import { DefaultTheme, defineConfig } from 'vitepress'
 import llmstxt from 'vitepress-plugin-llms'
+import { addCodemodGrepLinkToCatalogPage } from '../_data/codemod-grep'
 
 const gaScript = `
 window.dataLayer = window.dataLayer || [];
@@ -214,6 +215,13 @@ export default defineConfig({
       'link',
       { rel: 'canonical', href: canonicalUrl },
     ])
+  },
+  markdown: {
+    config(md) {
+      md.core.ruler.before('normalize', 'catalog-codemod-grep-link', (state) => {
+        state.src = addCodemodGrepLinkToCatalogPage(state.src, String(state.env.path || ''))
+      })
+    },
   },
   vite: {
     plugins: [llmstxt()],

--- a/website/_data/catalog.data.ts
+++ b/website/_data/catalog.data.ts
@@ -1,6 +1,7 @@
-import { JSON_SCHEMA, loadAll } from 'js-yaml'
 import { type ContentData, createContentLoader } from 'vitepress'
 import { ExampleLangs } from '../src/catalog/data'
+import { createCodemodGrepLink } from './codemod-grep'
+import { extractCatalogYaml, loadYAMLRules } from './utils'
 
 export interface RuleMeta {
   id: string
@@ -8,6 +9,7 @@ export interface RuleMeta {
   type: string
   link: string
   playgroundLink: string
+  grepLink: string | null
   language: ExampleLangs
   hasFix: boolean
   rules: string[]
@@ -40,7 +42,8 @@ function extractRuleInfo({ url, src }: ContentData): RuleMeta {
   const language = url.split('/')[2] as ExampleLangs
   const name = source.match(/##\s*([^<\n]+)/)?.[1] || ''
 
-  const yamls = extractYAMLRule(source)
+  const yaml = extractCatalogYaml(source)
+  const yamls = loadYAMLRules(yaml)
 
   return {
     id,
@@ -48,19 +51,12 @@ function extractRuleInfo({ url, src }: ContentData): RuleMeta {
     type,
     link: url,
     playgroundLink,
+    grepLink: createCodemodGrepLink({ language, playgroundLink, type, yaml }),
     language,
     hasFix,
     rules: extractUsedRules(yamls),
     features: extractUsedFeatures(yamls),
   }
-}
-
-function extractYAMLRule(source: string): Record<string, unknown>[] {
-  const yaml = source.match(/```ya?ml\n([\s\S]+?)\n```/)?.[1] || ''
-  if (!yaml) {
-    return []
-  }
-  return loadAll(yaml, null, { schema: JSON_SCHEMA }) as Record<string, unknown>[]
 }
 
 function extractUsedRules(yamls: Record<string, unknown>[]): string[] {

--- a/website/_data/codemod-grep.ts
+++ b/website/_data/codemod-grep.ts
@@ -1,0 +1,124 @@
+import { dump, JSON_SCHEMA } from 'js-yaml'
+import { extractCatalogYaml } from './utils'
+
+interface GrepLinkInput {
+  language: string
+  playgroundLink: string
+  type: 'Pattern' | 'YAML'
+  yaml: string
+}
+
+interface PlaygroundState {
+  query?: unknown
+  selector?: unknown
+}
+
+const CODEMOD_GREP_LANGUAGES = new Set([
+  'typescript',
+  'tsx',
+  'javascript',
+  'rust',
+  'python',
+  'go',
+  'c',
+  'cpp',
+  'java',
+  'scala',
+  'kotlin',
+  'php',
+  'swift',
+  'csharp',
+  'haskell',
+  'ruby',
+  'elixir',
+  'dart',
+  'bash',
+])
+const GREP_LINK_LABEL = 'View results in public repositories'
+
+export function addCodemodGrepLinkToCatalogPage(source: string, path: string): string {
+  const language = /(?:^|[/\\])catalog[/\\]([^/\\]+)[/\\][^/\\]+\.md$/.exec(path)?.[1]
+  const playground = /^(\* \[Playground Link\]\((.+)\))$/m.exec(source)
+  if (!language || !playground || source.includes(`[${GREP_LINK_LABEL}]`)) {
+    return source
+  }
+
+  const yaml = extractCatalogYaml(source)
+  const grepLink = createCodemodGrepLink({
+    language,
+    playgroundLink: playground[2],
+    type: yaml ? 'YAML' : 'Pattern',
+    yaml,
+  })
+  if (!grepLink) {
+    return source
+  }
+
+  return source.replace(
+    playground[1],
+    `${playground[1]}\n* [${GREP_LINK_LABEL}](${grepLink})`,
+  )
+}
+
+export function createCodemodGrepLink(input: GrepLinkInput): string | null {
+  if (!CODEMOD_GREP_LANGUAGES.has(input.language.toLowerCase())) {
+    return null
+  }
+
+  const query = createQuery(input)
+  if (!query) {
+    return null
+  }
+
+  const url = new URL('https://grep.codemod.com/')
+  url.searchParams.set('q', query.value)
+  url.searchParams.set('mode', query.mode)
+  url.searchParams.set('language', input.language)
+  return url.toString()
+}
+
+function createQuery(input: GrepLinkInput) {
+  if (input.type === 'YAML') {
+    return input.yaml ? { mode: 'yaml', value: input.yaml } : null
+  }
+
+  const state = decodePlaygroundState(input.playgroundLink)
+  if (!state || typeof state.query !== 'string' || !state.query) {
+    return null
+  }
+
+  if (typeof state.selector !== 'string' || !state.selector) {
+    return { mode: 'pattern', value: state.query }
+  }
+
+  return {
+    mode: 'yaml',
+    value: dump({
+      rule: {
+        pattern: {
+          context: state.query,
+          selector: state.selector,
+        },
+      },
+    }, {
+      lineWidth: -1,
+      noRefs: true,
+      schema: JSON_SCHEMA,
+    }).trimEnd(),
+  }
+}
+
+function decodePlaygroundState(link: string): PlaygroundState | null {
+  const encoded = link.split('#', 2)[1]
+  if (!encoded) {
+    return null
+  }
+
+  try {
+    const binary = atob(encoded)
+    const bytes = Uint8Array.from(binary, char => char.charCodeAt(0))
+    return JSON.parse(new TextDecoder().decode(bytes)) as PlaygroundState
+  } catch {
+    return null
+  }
+}

--- a/website/_data/utils.ts
+++ b/website/_data/utils.ts
@@ -1,0 +1,15 @@
+import { JSON_SCHEMA, loadAll } from 'js-yaml'
+
+export function loadYAMLRules(yaml: string): Record<string, unknown>[] {
+  if (!yaml) {
+    return []
+  }
+  return loadAll(yaml, null, { schema: JSON_SCHEMA }) as Record<
+    string,
+    unknown
+  >[]
+}
+
+export function extractCatalogYaml(source: string): string {
+  return source.match(/```ya?ml\n([\s\S]+?)\n```/)?.[1] || ''
+}

--- a/website/src/catalog/RuleItem.vue
+++ b/website/src/catalog/RuleItem.vue
@@ -103,9 +103,14 @@ const moreFeatures = computed(() => sortedFeatures.value.slice(2))
           </Badge>
         </a>
       </div>
-      <a :href="meta.playgroundLink" class="playground link" target="_blank">
-        Try in Playground →
-      </a>
+      <div class="rule-links">
+        <a :href="meta.playgroundLink" class="link" target="_blank">
+          Try in Playground →
+        </a>
+        <a v-if="meta.grepLink" :href="meta.grepLink" class="link" target="_blank">
+          Search in public repositories →
+        </a>
+      </div>
     </div>
   </li>
 </template>
@@ -178,7 +183,10 @@ a:hover {
 .rule-aux .rule-badges {
   justify-content: end;
 }
-.playground {
+.rule-links {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   font-size: 0.8em;
   white-space: nowrap;
   text-align: right;
@@ -214,6 +222,9 @@ a:hover {
   .rule-aux {
     flex: 1 0 auto;
     flex-direction: row;
+  }
+  .rule-links {
+    margin-left: auto;
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Search in public repositories” links to catalog rule pages.
  * Links generate searches based on each rule and supported language, including rules shared through the Playground.
  * Added the new search option alongside “Try in Playground,” with responsive layout updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->