### PR TITLE
docs(prompting): fix renamed skill repo links and marketplace-era install steps

### DIFF
--- a/website/advanced/prompting.md
+++ b/website/advanced/prompting.md
@@ -15,16 +15,29 @@ This skill teaches Claude how to write and use ast-grep rules to perform advance
 - "Find functions with more than 3 parameters"
 - "Search for console.log calls inside class methods"
 
-Clone or download the [ast-grep skill repository](https://github.com/ast-grep/claude-skill) to your Claude Code skills directory:
+The skill lives in the [ast-grep agent-skill repository](https://github.com/ast-grep/agent-skill), which is a Claude Code plugin marketplace. Install it with:
 
 ```bash
-# If you have a skills directory configured
-cp -r ast-grep ~/.claude/skills/
-
-# Or place it wherever your Claude Code skills are located
+npx skills add ast-grep/agent-skill
 ```
 
-The skill should be automatically detected by Claude Code. You can verify by checking available skills in Claude Code.
+Or from inside Claude Code:
+
+```
+/plugin marketplace add ast-grep/agent-skill
+/plugin install ast-grep
+```
+
+To install by hand instead, copy the skill directories out of the plugin. Claude Code expects each skill's `SKILL.md` at the top level of its own directory, so the plugin directory itself is one level too high:
+
+```bash
+git clone https://github.com/ast-grep/agent-skill.git
+cp -r agent-skill/ast-grep/skills/* ~/.claude/skills/
+```
+
+Claude Code then discovers the skill, which you can verify by checking its available skills.
+
+Discovered is not the same as preferred. Claude decides per query whether to reach for the skill, and it is always also holding a text-search tool that needs no setup. Name ast-grep in the request to invoke it directly, or set the standing instruction in the next section to make it the default.
 
 ## Simple Prompting in `AGENTS.md`
 

--- a/website/advanced/prompting.md
+++ b/website/advanced/prompting.md
@@ -32,6 +32,7 @@ To install by hand instead, copy the skill directories out of the plugin. Claude
 
 ```bash
 git clone https://github.com/ast-grep/agent-skill.git
+mkdir -p ~/.claude/skills
 cp -r agent-skill/ast-grep/skills/* ~/.claude/skills/
 ```
 

--- a/website/blog/how-to-debug.md
+++ b/website/blog/how-to-debug.md
@@ -21,7 +21,7 @@ head:
 # How to Debug ast-grep Rule Effectively
 
 :::tip Let Claude Debug For You
-If you prefer not to debug manually, try the [ast-grep Claude skill](https://github.com/ast-grep/claude-skill). It can explain AST structures, identify why rules don't match, and suggest fixes—all through natural conversation.
+If you prefer not to debug manually, try the [ast-grep Claude skill](https://github.com/ast-grep/agent-skill). It can explain AST structures, identify why rules don't match, and suggest fixes—all through natural conversation.
 :::
 
 Debugging ast-grep rules can be frustrating. You write what looks like a perfectly reasonable rule, test it against your code, and... nothing matches. Or worse, it matches things you didn't expect.


### PR DESCRIPTION
The Claude Code Skill section of `advanced/prompting.md` predates the skill repo becoming a plugin marketplace, so both its link and its install steps are stale.

- `github.com/ast-grep/claude-skill` now 301s to `github.com/ast-grep/agent-skill`. Same link in `blog/how-to-debug.md`.
- `cp -r ast-grep ~/.claude/skills/` no longer installs anything. `ast-grep/` is the plugin directory now, holding `.claude-plugin/plugin.json` and `skills/{ast-grep,outline}/`, so copying it lands `SKILL.md` at `~/.claude/skills/ast-grep/skills/ast-grep/SKILL.md`. Claude Code looks for it at `~/.claude/skills/<name>/SKILL.md` and finds nothing. Documented `npx skills add` and the `/plugin` flow first, with the corrected `cp -r agent-skill/ast-grep/skills/*` for a manual install.
- "The skill should be automatically detected by Claude Code" conflates discovery with selection. Claude Code does auto-discover the skill directory; whether Claude then reaches for it on a given query is a separate decision, made against a text-search tool that needs no setup. Split the two and pointed at the `AGENTS.md` section directly below, which is the existing answer to the second half.

Companion PR on the skill repo, where the same conflation produced two contradicting paragraphs: https://github.com/ast-grep/agent-skill/pull/12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude Code skill installation guidance with marketplace commands, in-app plugin commands, and a manual installation fallback.
  * Clarified how to make ast-grep the preferred tool through explicit requests or standing instructions.
  * Updated the debugging guide’s skill repository link to the current location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->